### PR TITLE
Add 'active effects' system, update for SMAPI 3.0, and prepare for Stardew Valley 1.3.33

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Xna.Framework.Input;
-using StardewModdingAPI;
-using StardewValley;
+﻿using StardewModdingAPI;
 
 namespace Magic
 {

--- a/Content.cs
+++ b/Content.cs
@@ -11,22 +11,22 @@ namespace Magic
     {
         public static Texture2D loadTexture( string path )
         {
-            return Mod.instance.Helper.Content.Load<Texture2D>( "res/" + path, ContentSource.ModFolder );
+            return Mod.instance.Helper.Content.Load<Texture2D>($"res/{path}", ContentSource.ModFolder );
         }
         public static string loadTextureKey(string path)
         {
-            return Mod.instance.Helper.Content.GetActualAssetKey("res/" + path, ContentSource.ModFolder);
+            return Mod.instance.Helper.Content.GetActualAssetKey($"res/{path}", ContentSource.ModFolder);
         }
 
         public static Map loadMap(string mapName, string variant = "map")
         {
-            string path = "res/" + mapName + "/" + variant + ".tmx";
+            string path = $"res/{mapName}/{variant}.tmx";
             return SpaceCore.Content.loadTmx(Mod.instance.Helper, mapName, path );
         }
 
         public static TileSheet loadTilesheet(string ts, Map xmap, out Dictionary< int, TileAnimation > animMapping )
         {
-            string path = "res/" + ts + ".tsx";
+            string path = $"res/{ts}.tsx";
             return SpaceCore.Content.loadTsx(Mod.instance.Helper, path, ts, xmap, out animMapping );
         }
     }

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -196,12 +196,12 @@ namespace Magic
             return spell.canCast(player, level);
         }
 
-        public static void castSpell(this Farmer player, string spellId, int level, int x = int.MinValue, int y = int.MinValue)
+        public static IActiveEffect castSpell(this Farmer player, string spellId, int level, int x = int.MinValue, int y = int.MinValue)
         {
-            castSpell(player, SpellBook.get(spellId), level, x, y);
+            return castSpell(player, SpellBook.get(spellId), level, x, y);
         }
 
-        public static void castSpell(this Farmer player, Spell spell, int level, int x = int.MinValue, int y = int.MinValue)
+        public static IActiveEffect castSpell(this Farmer player, Spell spell, int level, int x = int.MinValue, int y = int.MinValue)
         {
             if (player == Game1.player)
             {
@@ -218,7 +218,8 @@ namespace Magic
             Point pos = new Point(x, y);
             if (x == int.MinValue && y == int.MinValue)
                 pos = new Point(Game1.getMouseX() + Game1.viewport.X, Game1.getMouseY() + Game1.viewport.Y);
-            spell.onCast(player, level, pos.X, pos.Y);
+
+            return spell.onCast(player, level, pos.X, pos.Y);
         }
     }
 }

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -3,26 +3,25 @@ using Magic.Spells;
 using StardewValley;
 using System;
 using static Magic.Mod;
-using SFarmer = StardewValley.Farmer;
 using System.IO;
 
 namespace Magic
 {
     public static class Extensions
     {
-        private static void dataCheck( SFarmer player )
+        private static void dataCheck( Farmer player )
         {
             if (!Data.players.ContainsKey(player.UniqueMultiplayerID))
                 Data.players.Add(player.UniqueMultiplayerID, new MultiplayerSaveData.PlayerData());
         }
 
-        public static int getCurrentMana(this SFarmer player)
+        public static int getCurrentMana(this Farmer player)
         {
             dataCheck(player);
             return Data.players[ player.UniqueMultiplayerID ].mana;
         }
 
-        public static void addMana(this SFarmer player, int amt)
+        public static void addMana(this Farmer player, int amt)
         {
             dataCheck(player);
             Data.players[player.UniqueMultiplayerID].mana = Math.Max(0, Math.Min(player.getCurrentMana() + amt, player.getMaxMana()));
@@ -30,13 +29,13 @@ namespace Magic
                 Data.syncMineMini();
         }
 
-        public static int getMaxMana(this SFarmer player)
+        public static int getMaxMana(this Farmer player)
         {
             dataCheck(player);
             return Data.players[player.UniqueMultiplayerID].manaCap;
         }
 
-        public static void setMaxMana(this SFarmer player, int newCap )
+        public static void setMaxMana(this Farmer player, int newCap )
         {
             dataCheck(player);
             Data.players[player.UniqueMultiplayerID].manaCap = newCap;
@@ -44,19 +43,19 @@ namespace Magic
                 Data.syncMineMini();
         }
 
-        public static int getMagicLevel(this SFarmer player)
+        public static int getMagicLevel(this Farmer player)
         {
             dataCheck(player);
             return Data.players[player.UniqueMultiplayerID].magicLevel;
         }
 
-        public static int getMagicExp(this SFarmer player)
+        public static int getMagicExp(this Farmer player)
         {
             dataCheck(player);
             return Data.players[player.UniqueMultiplayerID].magicExp;
         }
 
-        public static void addMagicExp(this SFarmer player, int exp)
+        public static void addMagicExp(this Farmer player, int exp)
         {
             dataCheck(player);
             if (Data.players[player.UniqueMultiplayerID].magicLevel >= 50)
@@ -78,19 +77,19 @@ namespace Magic
             }
         }
 
-        public static int getMagicExpForNextLevel(this SFarmer player)
+        public static int getMagicExpForNextLevel(this Farmer player)
         {
             dataCheck(player);
             return 50 + Data.players[player.UniqueMultiplayerID].magicLevel * 50;
         }
 
-        public static int getFreeSpellPoints(this SFarmer player)
+        public static int getFreeSpellPoints(this Farmer player)
         {
             dataCheck(player);
             return Data.players[player.UniqueMultiplayerID].freePoints;
         }
 
-        public static void useSpellPoints(this SFarmer player, int amt, bool sync = true)
+        public static void useSpellPoints(this Farmer player, int amt, bool sync = true)
         {
             dataCheck(player);
             Data.players[player.UniqueMultiplayerID].freePoints -= amt;
@@ -98,26 +97,26 @@ namespace Magic
                 Data.syncMineFull();
         }
 
-        public static SpellBook getSpellBook(this SFarmer player)
+        public static SpellBook getSpellBook(this Farmer player)
         {
             dataCheck(player);
             return Data.players[player.UniqueMultiplayerID].spellBook;
         }
 
-        public static bool knowsSchool(this SFarmer player, string school)
+        public static bool knowsSchool(this Farmer player, string school)
         {
             if (player != Game1.player || Data == null)
                 return false;
             return player.getSpellBook().knownSchools.Contains(school);
         }
 
-        public static void learnSchool(this SFarmer player, string school)
+        public static void learnSchool(this Farmer player, string school)
         {
             if (!knowsSchool(player, school))
                 player.getSpellBook().knownSchools.Add(school);
         }
 
-        public static bool knowsSpell(this SFarmer player, string spellId, int level)
+        public static bool knowsSpell(this Farmer player, string spellId, int level)
         {
             if (player != Game1.player || Data == null)
                 return false;
@@ -125,12 +124,12 @@ namespace Magic
                    player.getSpellBook().knownSpells[spellId] >= level;
         }
 
-        public static bool knowsSpell(this SFarmer player, Spell spell, int level)
+        public static bool knowsSpell(this Farmer player, Spell spell, int level)
         {
             return knowsSpell(player, spell.FullId, level);
         }
 
-        public static int knowsSpellLevel(this SFarmer player, string spellId)
+        public static int knowsSpellLevel(this Farmer player, string spellId)
         {
             if (player != Game1.player || Data == null)
                 return -1;
@@ -139,12 +138,12 @@ namespace Magic
             return player.getSpellBook().knownSpells[spellId];
         }
 
-        public static int knowsSpellLevel(this SFarmer player, Spell spell)
+        public static int knowsSpellLevel(this Farmer player, Spell spell)
         {
             return knowsSpellLevel(player, spell.FullId);
         }
 
-        public static void learnSpell(this SFarmer player, string spellId, int level, bool free = false)
+        public static void learnSpell(this Farmer player, string spellId, int level, bool free = false)
         {
             int known = knowsSpellLevel(player, spellId);
             int diff = level - known;
@@ -160,12 +159,12 @@ namespace Magic
             Data.syncMineFull();
         }
 
-        public static void learnSpell(this SFarmer player, Spell spell, int level, bool free = false)
+        public static void learnSpell(this Farmer player, Spell spell, int level, bool free = false)
         {
             learnSpell(player, spell.FullId, level, free);
         }
 
-        public static void forgetSpell(this SFarmer player, string spellId, int level)
+        public static void forgetSpell(this Farmer player, string spellId, int level)
         {
             int known = knowsSpellLevel(player, spellId);
             if (level > known)
@@ -182,27 +181,27 @@ namespace Magic
             Data.syncMineFull();
         }
 
-        public static void forgetSpell(this SFarmer player, Spell spell, int level)
+        public static void forgetSpell(this Farmer player, Spell spell, int level)
         {
             forgetSpell(player, spell.FullId, level);
         }
 
-        public static bool canCastSpell(this SFarmer player, string spellId, int level)
+        public static bool canCastSpell(this Farmer player, string spellId, int level)
         {
             return SpellBook.get(spellId).canCast(player, level);
         }
         
-        public static bool canCastSpell(this SFarmer player, Spell spell, int level)
+        public static bool canCastSpell(this Farmer player, Spell spell, int level)
         {
             return spell.canCast(player, level);
         }
 
-        public static void castSpell(this SFarmer player, string spellId, int level, int x = int.MinValue, int y = int.MinValue)
+        public static void castSpell(this Farmer player, string spellId, int level, int x = int.MinValue, int y = int.MinValue)
         {
             castSpell(player, SpellBook.get(spellId), level, x, y);
         }
 
-        public static void castSpell(this SFarmer player, Spell spell, int level, int x = int.MinValue, int y = int.MinValue)
+        public static void castSpell(this Farmer player, Spell spell, int level, int x = int.MinValue, int y = int.MinValue)
         {
             if (player == Game1.player)
             {

--- a/Game/CloudMount.cs
+++ b/Game/CloudMount.cs
@@ -15,7 +15,6 @@ namespace Magic.Game
         }
 
         //private bool dismountedOnce = false;
-        private StardewValley.Farmer prevRider = null;
         public override void update(GameTime time, GameLocation location)
         {
             base.update(time, location);
@@ -39,7 +38,6 @@ namespace Magic.Game
 
             rider.speed = 10;
             rider.temporaryImpassableTile = new Rectangle((int)rider.position.X - Game1.tileSize, (int)rider.position.Y - Game1.tileSize, Game1.tileSize * 3, Game1.tileSize * 3);
-            prevRider = rider;
         }
 
         public override void draw(SpriteBatch b)
@@ -48,7 +46,7 @@ namespace Magic.Game
             b.Draw(tex, getLocalPosition(Game1.viewport) + new Vector2( -Game1.tileSize * 0.90f, -Game1.tileSize * 0.75f ), null, Color.White, 0, Vector2.Zero, Game1.pixelZoom, SpriteEffects.None, 1);
         }
 
-        public override bool checkAction(StardewValley.Farmer who, GameLocation l)
+        public override bool checkAction(Farmer who, GameLocation l)
         {
             if (rider == null)
                 return false;

--- a/Game/Interface/MagicLevelUpMenu.cs
+++ b/Game/Interface/MagicLevelUpMenu.cs
@@ -6,7 +6,6 @@ using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Magic;
 
 namespace Magic.Game.Interface
 {

--- a/Game/Interface/MagicMenu.cs
+++ b/Game/Interface/MagicMenu.cs
@@ -1,12 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Magic;
 using Magic.Schools;
 using Magic.Spells;
 using StardewValley;
 using StardewValley.Menus;
-using System.Linq;
-//using StardewMountain.Combat.Magic;
 
 namespace Magic.Game.Interface
 {

--- a/Game/Interface/TeleportMenu.cs
+++ b/Game/Interface/TeleportMenu.cs
@@ -1,13 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using SpaceCore.Utilities;
 using StardewValley;
-using StardewValley.Characters;
 using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
-//using SpaceCore.Utilities;
-//using StardewValley.Characters;
 
 namespace Magic.Game.Interface
 {

--- a/Game/SpellProjectile.cs
+++ b/Game/SpellProjectile.cs
@@ -1,19 +1,17 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Magic;
 using Magic.Spells;
 using StardewValley;
 using StardewValley.Monsters;
 using StardewValley.Projectiles;
 using StardewValley.TerrainFeatures;
 using System;
-using SFarmer = StardewValley.Farmer;
 
 namespace Magic.Game
 {
     class SpellProjectile : Projectile
     {
-        private readonly SFarmer source;
+        private readonly Farmer source;
         private readonly ProjectileSpell spell;
         private readonly int damage;
         private readonly float dir;
@@ -22,7 +20,7 @@ namespace Magic.Game
         private Texture2D tex;
         private string texId;
 
-        public SpellProjectile(SFarmer theSource, ProjectileSpell theSpell, int dmg, float theDir, float theVel )
+        public SpellProjectile(Farmer theSource, ProjectileSpell theSpell, int dmg, float theDir, float theVel )
         {
             source = theSource;
             spell = theSpell;

--- a/IActiveEffect.cs
+++ b/IActiveEffect.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI.Events;
+
+namespace Magic
+{
+    /// <summary>An active spell, projectile, or effect which should be updated or drawn.</summary>
+    public interface IActiveEffect
+    {
+        /// <summary>Update the effect state if needed.</summary>
+        /// <param name="e">The update tick event args.</param>
+        /// <returns>Returns true if the effect is still active, or false if it can be discarded.</returns>
+        bool Update(UpdateTickedEventArgs e);
+
+        /// <summary>Draw the effect to the screen if needed.</summary>
+        /// <param name="spriteBatch">The sprite batch being drawn.</param>
+        void Draw(SpriteBatch spriteBatch);
+    }
+}

--- a/Magic.cs
+++ b/Magic.cs
@@ -1,21 +1,16 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using SpaceCore.Events;
 using StardewModdingAPI.Events;
 using Magic.Game.Interface;
 using Magic.Schools;
 using Magic.Spells;
 using StardewValley;
-using StardewValley.Locations;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using static Magic.Mod;
-using SpaceCore;
 using Magic.Other;
-using StardewModdingAPI;
 using StardewValley.Network;
 using Newtonsoft.Json;
 using System.IO;
@@ -316,7 +311,7 @@ namespace Magic
         internal static List<int> newMagicLevels = new List<int>();
         private static void showMagicLevelMenus(object sender, EventArgsShowNightEndMenus args)
         {
-            if (newMagicLevels.Count() > 0)
+            if (newMagicLevels.Any())
             {
                 for (int i = newMagicLevels.Count() - 1; i >= 0; --i)
                 {
@@ -339,7 +334,7 @@ namespace Magic
 
         public static void placeAltar(string locName, int x, int y, int baseAltarIndex, string school)
         {
-            Log.debug("Placing altar @ " + locName + "(" + x + ", " + y + ")");
+            Log.debug($"Placing altar @ {locName}({x}, {y})");
 
             // AddTileSheet sorts the tilesheets by ID after adding them.
             // The game sometimes refers to tilesheets by their index (such as in Beach.fixBridge)

--- a/Magic.cs
+++ b/Magic.cs
@@ -35,14 +35,14 @@ namespace Magic
         public const string MSG_MINIDATA = "spacechase0.Magic.MiniData";
         public const string MSG_CAST = "spacechase0.Magic.Cast";
 
-        internal static void init(IModEvents events, IInputHelper inputHelper)
+        internal static void init(IModEvents events, IInputHelper inputHelper, Func<long> getNewId)
         {
             Magic.events = events;
             Magic.inputHelper = inputHelper;
 
             loadAssets();
 
-            SpellBook.init();
+            SpellBook.init(getNewId);
 
             events.GameLoop.SaveLoaded += onSaveLoaded;
             events.GameLoop.UpdateTicked += onUpdateTicked;

--- a/Magic.cs
+++ b/Magic.cs
@@ -14,35 +14,44 @@ using Magic.Other;
 using StardewValley.Network;
 using Newtonsoft.Json;
 using System.IO;
+using StardewModdingAPI;
 
 namespace Magic
 {
     // TODO: Refactor this mess
     static class Magic
     {
+        private static IModEvents events;
+        private static IInputHelper inputHelper;
+
         private static Texture2D spellBg;
         private static Texture2D manaBg;
         private static Texture2D manaFg;
+
+        /// <summary>The active effects, spells, or projectiles which should be updated or drawn.</summary>
+        private static readonly IList<IActiveEffect> activeEffects = new List<IActiveEffect>();
 
         public const string MSG_DATA = "spacechase0.Magic.Data";
         public const string MSG_MINIDATA = "spacechase0.Magic.MiniData";
         public const string MSG_CAST = "spacechase0.Magic.Cast";
 
-        internal static void init()
+        internal static void init(IModEvents events, IInputHelper inputHelper)
         {
+            Magic.events = events;
+            Magic.inputHelper = inputHelper;
+
             loadAssets();
 
             SpellBook.init();
 
-            SaveEvents.AfterLoad += afterLoad;
+            events.GameLoop.SaveLoaded += onSaveLoaded;
+            events.GameLoop.UpdateTicked += onUpdateTicked;
 
-            InputEvents.ButtonPressed += onKeyPress;
-            InputEvents.ButtonReleased += onKeyRelease;
+            events.Input.ButtonPressed += onButtonPressed;
+            events.Input.ButtonReleased += onButtonReleased;
             
-            TimeEvents.AfterDayStarted += onNewDay;
-            PlayerEvents.Warped += EvacSpell.onLocationChanged;
-            MineEvents.MineLevelChanged += EvacSpell.onMineLevelChanged;
-            PlayerEvents.Warped += eventChecks;
+            events.GameLoop.DayStarted += onDayStarted;
+            events.Player.Warped += onWarped;
             
             SpaceEvents.OnBlankSave += onBlankSave;
             SpaceEvents.ShowNightEndMenus += showMagicLevelMenus;
@@ -53,7 +62,8 @@ namespace Magic
             SpaceCore.Networking.RegisterMessageHandler(MSG_CAST, onNetworkCast);
             SpaceEvents.ServerGotClient += onClientConnected;
 
-            GraphicsEvents.OnPostRenderHudEvent += renderHud;
+            events.Display.RenderingHud += onRenderingHud;
+            events.Display.RenderedHud += onRenderedHud;
 
             checkForExperienceBars();
 
@@ -83,7 +93,9 @@ namespace Magic
 
         private static void onNetworkCast( IncomingMessage msg )
         {
-            Game1.getFarmer(msg.FarmerID).castSpell(msg.Reader.ReadString(), msg.Reader.ReadInt32(), msg.Reader.ReadInt32(), msg.Reader.ReadInt32());
+            IActiveEffect effect = Game1.getFarmer(msg.FarmerID).castSpell(msg.Reader.ReadString(), msg.Reader.ReadInt32(), msg.Reader.ReadInt32(), msg.Reader.ReadInt32());
+            if (effect != null)
+                activeEffects.Add(effect);
         }
 
         private static void onClientConnected(object sender, EventArgsServerGotClient args)
@@ -113,7 +125,10 @@ namespace Magic
             placeAltar("WitchHut", 6, 8, 54 * 7, SchoolId.Eldritch);
         }
 
-        public static void afterLoad( object sender, EventArgs args )
+        /// <summary>Raised after the player loads a save slot.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        public static void onSaveLoaded( object sender, SaveLoadedEventArgs e )
         {
             Data.players[ Game1.player.UniqueMultiplayerID ].spellBook.Owner = Game1.player;
             foreach ( var farmer in Game1.otherFarmers )
@@ -122,11 +137,39 @@ namespace Magic
             }
         }
 
-        public static void renderHud( object sender, EventArgs args )
+        /// <summary>Raised after the game state is updated (≈60 times per second).</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private static void onUpdateTicked(object sender, UpdateTickedEventArgs e)
         {
-            if (Game1.activeClickableMenu != null || Game1.eventUp) return;
-            if (Game1.player.getMaxMana() == 0) return;
-            SpriteBatch b = Game1.spriteBatch;
+            // update active effects
+            for (int i = activeEffects.Count - 1; i >= 0; i--)
+            {
+                IActiveEffect effect = activeEffects[i];
+                if (!effect.Update(e))
+                    activeEffects.RemoveAt(i);
+            }
+        }
+
+        /// <summary>Raised before drawing the HUD (item toolbar, clock, etc) to the screen. The vanilla HUD may be hidden at this point (e.g. because a menu is open). Content drawn to the sprite batch at this point will appear under the HUD.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private static void onRenderingHud( object sender, RenderingHudEventArgs e )
+        {
+            // draw active effects
+            foreach (IActiveEffect effect in activeEffects)
+                effect.Draw(e.SpriteBatch);
+        }
+
+        /// <summary>Raised after drawing the HUD (item toolbar, clock, etc) to the sprite batch, but before it's rendered to the screen. The vanilla HUD may be hidden at this point (e.g. because a menu is open).</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        public static void onRenderedHud( object sender, RenderedHudEventArgs e )
+        {
+            if (Game1.activeClickableMenu != null || Game1.eventUp || Game1.player.getMaxMana() == 0)
+                return;
+
+            SpriteBatch b = e.SpriteBatch;
             
             Vector2 manaPos = new Vector2(20, Game1.viewport.Height - manaBg.Height * 4 - 20);
             b.Draw(manaBg, manaPos, new Rectangle(0, 0, manaBg.Width, manaBg.Height), Color.White, 0, new Vector2(), 4, SpriteEffects.None, 1);
@@ -204,29 +247,33 @@ namespace Magic
         }
 
         private static bool castPressed = false;
-        private static void onKeyPress(object sender, EventArgsInput args)
+
+        /// <summary>Raised after the player presses a button on the keyboard, controller, or mouse.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private static void onButtonPressed(object sender, ButtonPressedEventArgs e)
         {
-            if (args.Button == Config.Key_Cast)
+            if (e.Button == Config.Key_Cast)
             {
                 castPressed = true;
             }
 
             if (Data == null || Game1.activeClickableMenu != null) return;
-            if (args.Button == Config.Key_SwapSpells)
+            if (e.Button == Config.Key_SwapSpells)
             {
                 Game1.player.getSpellBook().swapPreparedSet();
             }
             else if (castPressed &&
-                      (args.Button == Config.Key_Spell1 || args.Button == Config.Key_Spell2 ||
-                        args.Button == Config.Key_Spell3 || args.Button == Config.Key_Spell4))
+                      (e.Button == Config.Key_Spell1 || e.Button == Config.Key_Spell2 ||
+                        e.Button == Config.Key_Spell3 || e.Button == Config.Key_Spell4))
             {
                 int slot = 0;
-                if (args.Button == Config.Key_Spell1) slot = 0;
-                else if (args.Button == Config.Key_Spell2) slot = 1;
-                else if (args.Button == Config.Key_Spell3) slot = 2;
-                else if (args.Button == Config.Key_Spell4) slot = 3;
+                if (e.Button == Config.Key_Spell1) slot = 0;
+                else if (e.Button == Config.Key_Spell2) slot = 1;
+                else if (e.Button == Config.Key_Spell3) slot = 2;
+                else if (e.Button == Config.Key_Spell4) slot = 3;
 
-                args.SuppressButton();
+                Magic.inputHelper.Suppress(e.Button);
 
                 SpellBook book = Game1.player.getSpellBook();
                 PreparedSpell[] prepared = book.getPreparedSpells();
@@ -242,31 +289,50 @@ namespace Magic
                 if (Game1.player.canCastSpell(toCast, prep.Level))
                 {
                     Log.trace("Casting " + prep.SpellId);
-                    Game1.player.castSpell(toCast, prep.Level);
+
+                    IActiveEffect effect = Game1.player.castSpell(toCast, prep.Level);
+                    if (effect != null)
+                        activeEffects.Add(effect);
                     Game1.player.addMana(-toCast.getManaCost(Game1.player, prep.Level));
                 }
             }
         }
 
-        private static void onKeyRelease(object sender, EventArgsInput args)
+        /// <summary>Raised after the player releases a button on the keyboard, controller, or mouse.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private static void onButtonReleased(object sender, ButtonReleasedEventArgs e)
         {
-            if (args.Button == Config.Key_Cast)
+            if (e.Button == Config.Key_Cast)
             {
                 castPressed = false;
             }
         }
 
-        private static void onNewDay(object sender, EventArgs args)
+        /// <summary>Raised after the game begins a new day (including when the player loads a save).</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private static void onDayStarted(object sender, DayStartedEventArgs e)
         {
             Game1.player.addMana(Game1.player.getMaxMana());
         }
 
-        private static void eventChecks( object sender, EventArgsPlayerWarped args )
+        /// <summary>Raised after a player warps to a new location.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private static void onWarped( object sender, WarpedEventArgs e )
         {
-            if ( args.NewLocation.Name == "WizardHouse" && !Game1.player.eventsSeen.Contains( 90000 ) &&
+            if (!e.IsLocalPlayer)
+                return;
+
+            // update spells
+            EvacSpell.onLocationChanged();
+
+            // check events
+            if ( e.NewLocation.Name == "WizardHouse" && !Game1.player.eventsSeen.Contains( 90000 ) &&
                  Game1.player.friendshipData.ContainsKey( "Wizard" ) && Game1.player.friendshipData[ "Wizard" ].Points > 750 )
             {
-                args.NewLocation.currentEvent = new Event("WizardSong/0 5/Wizard 8 5 0 farmer 8 15 0/move farmer 0 -8 0/speak Wizard \"TODO#$b#Find one of the five altars and learn some magic.#$b#Q to start casting, then 1-4 to choose the spell.#$b#TAB to switch between spell sets.\"/textAboveHead Wizard \"MAGIC\"/pause 750/fade 750/end", 90000);
+                e.NewLocation.currentEvent = new Event("WizardSong/0 5/Wizard 8 5 0 farmer 8 15 0/move farmer 0 -8 0/speak Wizard \"TODO#$b#Find one of the five altars and learn some magic.#$b#Q to start casting, then 1-4 to choose the spell.#$b#TAB to switch between spell sets.\"/textAboveHead Wizard \"MAGIC\"/pause 750/fade 750/end", 90000);
                 Game1.eventUp = true;
                 Game1.displayHUD = false;
                 Game1.player.CanMove = false;
@@ -381,10 +447,13 @@ namespace Magic
             }
             
             Log.info("Experience Bars found, adding magic experience bar renderer.");
-            GraphicsEvents.OnPostRenderHudEvent += drawExperienceBar;
+            Magic.events.Display.RenderedHud += drawExperienceBar;
         }
 
-        private static void drawExperienceBar(object sender, EventArgs args_)
+        /// <summary>Raised after drawing the HUD (item toolbar, clock, etc) to the sprite batch, but before it's rendered to the screen. The vanilla HUD may be hidden at this point (e.g. because a menu is open).</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private static void drawExperienceBar(object sender, RenderedHudEventArgs e)
         {
             if (Game1.activeClickableMenu != null)
                 return;
@@ -406,14 +475,14 @@ namespace Magic
                 if (api == null)
                 {
                     Log.warn("No experience bars API? Turning off");
-                    GraphicsEvents.OnPostRenderHudEvent -= drawExperienceBar;
+                    events.Display.RenderedHud -= drawExperienceBar;
                 }
                 api.DrawExperienceBar(expIcon, level, progress, new Color(0, 66, 255));
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Log.error("Exception rendering magic experience bar: " + e);
-                GraphicsEvents.OnPostRenderHudEvent -= drawExperienceBar;
+                Log.error("Exception rendering magic experience bar: " + ex);
+                events.Display.RenderedHud -= drawExperienceBar;
             }
         }
 

--- a/Magic.csproj
+++ b/Magic.csproj
@@ -12,8 +12,6 @@
     <AssemblyName>Magic</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,9 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -110,7 +105,6 @@
     </None>
     <None Include="i18n\default.json" />
     <None Include="manifest.json" />
-    <None Include="packages.config" />
     <None Include="res\altarsobjects.psd" />
   </ItemGroup>
   <ItemGroup>
@@ -281,9 +275,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\SpaceCore\SpaceCore.csproj">
       <Project>{ba657cb4-93ed-4c3a-a66e-86954beb4ce6}</Project>
       <Name>SpaceCore</Name>
@@ -295,12 +286,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180428" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/Magic.csproj
+++ b/Magic.csproj
@@ -287,8 +287,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180428" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Magic.csproj
+++ b/Magic.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Command.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="Content.cs" />
+    <Compile Include="IActiveEffect.cs" />
     <Compile Include="Log.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Game\CloudMount.cs" />

--- a/Mod.cs
+++ b/Mod.cs
@@ -4,6 +4,7 @@ using StardewValley;
 using System;
 using System.IO;
 using Magic.Other;
+using Newtonsoft.Json;
 
 namespace Magic
 {
@@ -14,10 +15,6 @@ namespace Magic
         public static Configuration Config { get; private set; }
         
         internal static JsonAssetsApi ja;
-
-        public Mod()
-        {
-        }
 
         public override void Entry(IModHelper helper)
         {
@@ -51,20 +48,26 @@ namespace Magic
             {
                 if (!Game1.IsMultiplayer || Game1.IsMasterGame)
                 {
-                    Log.info("Loading save data (\"" + SaveData.FilePath + "\")...");
-                    var oldData = Helper.ReadJsonFile<SaveData>(SaveData.FilePath);
+                    Log.info($"Loading save data (\"{SaveData.FilePath}\")...");
+                    var oldData = File.Exists(SaveData.FilePath)
+                        ? JsonConvert.DeserializeObject<SaveData>(File.ReadAllText(SaveData.FilePath))
+                        : null;
+                    Data = File.Exists(MultiplayerSaveData.FilePath)
+                        ? JsonConvert.DeserializeObject<MultiplayerSaveData>(File.ReadAllText(MultiplayerSaveData.FilePath))
+                        : new MultiplayerSaveData();
 
-                    Data = Helper.ReadJsonFile<MultiplayerSaveData>(MultiplayerSaveData.FilePath) ?? new MultiplayerSaveData();
                     if (oldData != null && !Data.players.ContainsKey(Game1.MasterPlayer.UniqueMultiplayerID))
                     {
-                        var player = new MultiplayerSaveData.PlayerData();
-                        player.mana = oldData.mana;
-                        player.manaCap = oldData.manaCap;
-                        player.magicLevel = oldData.magicLevel;
-                        player.magicExp = oldData.magicExp;
-                        player.freePoints = oldData.freePoints;
-                        player.spellBook = oldData.spellBook;
-                        
+                        var player = new MultiplayerSaveData.PlayerData
+                        {
+                            mana = oldData.mana,
+                            manaCap = oldData.manaCap,
+                            magicLevel = oldData.magicLevel,
+                            magicExp = oldData.magicExp,
+                            freePoints = oldData.freePoints,
+                            spellBook = oldData.spellBook
+                        };
+
                         Data.players[Game1.MasterPlayer.UniqueMultiplayerID] = player;
                     }
                     
@@ -82,8 +85,8 @@ namespace Magic
         {
             if (!Game1.IsMultiplayer || Game1.IsMasterGame)
             {
-                Log.info("Saving save data (\"" + MultiplayerSaveData.FilePath + "\")...");
-                Helper.WriteJsonFile(MultiplayerSaveData.FilePath, Data);
+                Log.info($"Saving save data (\"{MultiplayerSaveData.FilePath}\")...");
+                File.WriteAllText(MultiplayerSaveData.FilePath, JsonConvert.SerializeObject(Data));
             }
         }
     }

--- a/Mod.cs
+++ b/Mod.cs
@@ -1,13 +1,9 @@
-﻿using MoreRings.Other;
-using SpaceCore.Utilities;
-using StardewModdingAPI;
+﻿using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
-using StardewValley.Menus;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
+using Magic.Other;
 
 namespace Magic
 {

--- a/Mod.cs
+++ b/Mod.cs
@@ -26,7 +26,7 @@ namespace Magic
             helper.Events.GameLoop.SaveLoaded += onSaveLoaded;
             helper.Events.GameLoop.Saved += onSaved;
 
-            Magic.init(helper.Events, helper.Input);
+            Magic.init(helper.Events, helper.Input, helper.Multiplayer.GetNewID);
         }
 
         /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>

--- a/MultiplayerSaveData.cs
+++ b/MultiplayerSaveData.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using SpaceCore.Utilities;
 using StardewModdingAPI;
 using StardewValley;
 using System.Collections.Generic;

--- a/Other/ExperienceBars.cs
+++ b/Other/ExperienceBars.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 
 namespace Magic.Other

--- a/Other/JsonAssetsApi.cs
+++ b/Other/JsonAssetsApi.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MoreRings.Other
+﻿namespace Magic.Other
 {
     public interface JsonAssetsApi
     {

--- a/SaveData.cs
+++ b/SaveData.cs
@@ -1,7 +1,4 @@
-﻿using SpaceCore.Utilities;
-using StardewModdingAPI;
-using StardewValley;
-using System.Collections.Generic;
+﻿using StardewModdingAPI;
 using System.IO;
 
 namespace Magic

--- a/SpellBook.cs
+++ b/SpellBook.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Magic.Schools;
 using Magic.Spells;
 using System.Collections.Generic;
@@ -11,7 +12,7 @@ namespace Magic
     {
         //private static Spell UNKNOWN_SPELL = new DummySpell("unknown");
 
-        private static Dictionary<string, Spell> spells = new Dictionary<string, Spell>();
+        private static readonly Dictionary<string, Spell> spells = new Dictionary<string, Spell>();
 
         public static void register( Spell spell )
         {
@@ -34,14 +35,14 @@ namespace Magic
             return spells.Keys.ToList<string>();
         }
 
-        internal static void init()
+        internal static void init(Func<long> getNewId)
         {
             register(new ClearDebrisSpell());
             register(new TillSpell());
             register(new WaterSpell());
             register(new BlinkSpell());
 
-            register(new LanternSpell());
+            register(new LanternSpell(getNewId));
             register(new TendrilsSpell());
             register(new ShockwaveSpell());
             register(new PhotosynthesisSpell());

--- a/SpellBook.cs
+++ b/SpellBook.cs
@@ -3,7 +3,7 @@ using Magic.Schools;
 using Magic.Spells;
 using System.Collections.Generic;
 using System.Linq;
-using SFarmer = StardewValley.Farmer;
+using StardewValley;
 
 namespace Magic
 {
@@ -21,7 +21,7 @@ namespace Magic
 
         public static Spell get( string id )
         {
-            if (id == null || id == "")
+            if (string.IsNullOrEmpty(id))
                 return null;
             if (!spells.ContainsKey(id))
                 return null;// UNKNOWN_SPELL;
@@ -63,7 +63,7 @@ namespace Magic
 
 
         [JsonIgnore]
-        public SFarmer Owner { get; internal set; }
+        public Farmer Owner { get; internal set; }
 
         public Dictionary<string, int> knownSpells = new Dictionary<string, int>();
         public HashSet<string> knownSchools = new HashSet<string>();

--- a/Spells/BlinkSpell.cs
+++ b/Spells/BlinkSpell.cs
@@ -19,13 +19,15 @@ namespace Magic.Spells
             return 1;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
-            Log.debug(player.Name + " casted Blink.");
+            Log.debug($"{player.Name} cast Blink.");
             player.position.X = targetX - player.GetBoundingBox().Width / 2;
             player.position.Y = targetY - player.GetBoundingBox().Height / 2;
             Game1.playSound("powerup");
             player.addMagicExp(5);
+
+            return null;
         }
     }
 }

--- a/Spells/BlinkSpell.cs
+++ b/Spells/BlinkSpell.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Magic.Schools;
+﻿using Magic.Schools;
 using StardewValley;
-using SFarmer = StardewValley.Farmer;
 
 namespace Magic.Spells
 {
@@ -11,7 +9,7 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(SFarmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 5;
         }
@@ -21,7 +19,7 @@ namespace Magic.Spells
             return 1;
         }
 
-        public override void onCast(SFarmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             Log.debug(player.Name + " casted Blink.");
             player.position.X = targetX - player.GetBoundingBox().Width / 2;

--- a/Spells/BloodManaSpell.cs
+++ b/Spells/BloodManaSpell.cs
@@ -23,9 +23,9 @@ namespace Magic.Spells
             return player.getCurrentMana() != player.getMaxMana() && player.health > 10 + 10 * level;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
-            Log.debug(player.Name + " casted Blood Mana.");
+            Log.debug($"{player.Name} cast Blood Mana.");
 
             int health = 10 + 10 * level;
             player.health -= health;
@@ -40,6 +40,8 @@ namespace Magic.Spells
             player.addMagicExp(-mana);
             if (player.getMagicExp() < 0)
                 player.addMagicExp(-player.getMagicExp());
+
+            return null;
         }
     }
 }

--- a/Spells/BloodManaSpell.cs
+++ b/Spells/BloodManaSpell.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Magic.Schools;
 using StardewValley;
-using SFarmer = StardewValley.Farmer;
 
 namespace Magic.Spells
 {
@@ -14,17 +13,17 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(SFarmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override bool canCast(SFarmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             return player.getCurrentMana() != player.getMaxMana() && player.health > 10 + 10 * level;
         }
 
-        public override void onCast(SFarmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             Log.debug(player.Name + " casted Blood Mana.");
 

--- a/Spells/BuffSpell.cs
+++ b/Spells/BuffSpell.cs
@@ -29,15 +29,15 @@ namespace Magic.Spells
             return 10;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             if (player != Game1.player)
-                return;
+                return null;
 
             foreach ( var buff in Game1.buffsDisplay.otherBuffs )
             {
                 if (buff.source == "spell:life:buff")
-                    return;
+                    return null;
             }
 
             Game1.buffsDisplay.clearAllBuffs();
@@ -59,6 +59,7 @@ namespace Magic.Spells
 
             Game1.buffsDisplay.addOtherBuff(new Buff(farm, fish, mine, 0, luck, forage, 0, 0, 0, 0, def, atk, 60 + level * 120, "spell:light:buff", "Buff (spell)"));
             player.addMagicExp(10);
+            return null;
         }
     }
 }

--- a/Spells/BuffSpell.cs
+++ b/Spells/BuffSpell.cs
@@ -10,7 +10,7 @@ namespace Magic.Spells
         {
         }
 
-        public override bool canCast(StardewValley.Farmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             if (player == Game1.player)
             {
@@ -24,12 +24,12 @@ namespace Magic.Spells
             return base.canCast(player, level);
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 10;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             if (player != Game1.player)
                 return;

--- a/Spells/ClearDebrisSpell.cs
+++ b/Spells/ClearDebrisSpell.cs
@@ -21,7 +21,7 @@ namespace Magic.Spells
             return 0;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             level += 1;
             targetX /= Game1.tileSize;
@@ -39,7 +39,7 @@ namespace Magic.Spells
                 for (int iy = targetY - level; iy <= targetY + level; ++iy)
                 {
                     if (player.getCurrentMana() <= 0)
-                        return;
+                        return null;
 
                     Vector2 pos = new Vector2(ix, iy);
 
@@ -122,6 +122,8 @@ namespace Magic.Spells
                     }
                 }
             }
+
+            return null;
         }
     }
 }

--- a/Spells/ClearDebrisSpell.cs
+++ b/Spells/ClearDebrisSpell.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using SpaceCore.Utilities;
 using Magic.Schools;
 using StardewValley;
 using StardewValley.Locations;
@@ -17,12 +16,12 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             level += 1;
             targetX /= Game1.tileSize;

--- a/Spells/DescendSpell.cs
+++ b/Spells/DescendSpell.cs
@@ -10,17 +10,17 @@ namespace Magic.Spells
         {
         }
 
-        public override bool canCast(StardewValley.Farmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             return base.canCast(player, level) && player.currentLocation is MineShaft;
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 15;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             if (player != Game1.player)
                 return;

--- a/Spells/DescendSpell.cs
+++ b/Spells/DescendSpell.cs
@@ -20,14 +20,14 @@ namespace Magic.Spells
             return 15;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             if (player != Game1.player)
-                return;
+                return null;
 
             var ms = player.currentLocation as MineShaft;
             if (ms == null)
-                return;
+                return null;
 
             int target = ms.mineLevel + 1 + 2 * level;
             if ( ms.mineLevel <= 120 && target >= 120 )
@@ -40,6 +40,7 @@ namespace Magic.Spells
             Game1.enterMine(target);
 
             player.addMagicExp(5);
+            return null;
         }
     }
 }

--- a/Spells/DummySpell.cs
+++ b/Spells/DummySpell.cs
@@ -1,4 +1,4 @@
-﻿using SFarmer = StardewValley.Farmer;
+﻿using StardewValley;
 
 namespace Magic.Spells
 {
@@ -8,12 +8,12 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(SFarmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override void onCast(SFarmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             Log.debug(player.Name + " casted " + Id + ".");
         }

--- a/Spells/DummySpell.cs
+++ b/Spells/DummySpell.cs
@@ -13,9 +13,10 @@ namespace Magic.Spells
             return 0;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
-            Log.debug(player.Name + " casted " + Id + ".");
+            Log.debug($"{player.Name} cast {Id}.");
+            return null;
         }
     }
 }

--- a/Spells/EvacSpell.cs
+++ b/Spells/EvacSpell.cs
@@ -15,12 +15,12 @@ namespace Magic.Spells
             return 1;
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 5;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             player.position.X = enterX;
             player.position.Y = enterY;

--- a/Spells/EvacSpell.cs
+++ b/Spells/EvacSpell.cs
@@ -20,20 +20,16 @@ namespace Magic.Spells
             return 5;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             player.position.X = enterX;
             player.position.Y = enterY;
             player.addMagicExp(5);
+            return null;
         }
 
         private static float enterX, enterY;
-        internal static void onLocationChanged( object sender, EventArgsPlayerWarped args )
-        {
-            enterX = Game1.player.position.X;
-            enterY = Game1.player.position.Y;
-        }
-        internal static void onMineLevelChanged(object sender, EventArgsMineLevelChanged args)
+        internal static void onLocationChanged()
         {
             enterX = Game1.player.position.X;
             enterY = Game1.player.position.Y;

--- a/Spells/HasteSpell.cs
+++ b/Spells/HasteSpell.cs
@@ -28,19 +28,20 @@ namespace Magic.Spells
             return 10;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             if (player != Game1.player)
-                return;
+                return null;
 
             foreach ( var buff in Game1.buffsDisplay.otherBuffs )
             {
                 if (buff.source == "spell:life:haste")
-                    return;
+                    return null;
             }
 
             Game1.buffsDisplay.addOtherBuff(new Buff(0, 0, 0, 0, 0, 0, 0, 0, 0, level + 1, 0, 0, 60 + level * 120, "spell:air:haste", "Haste (spell)"));
             player.addMagicExp(10);
+            return null;
         }
     }
 }

--- a/Spells/HasteSpell.cs
+++ b/Spells/HasteSpell.cs
@@ -9,7 +9,7 @@ namespace Magic.Spells
         {
         }
 
-        public override bool canCast(StardewValley.Farmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             if (player == Game1.player)
             {
@@ -23,12 +23,12 @@ namespace Magic.Spells
             return base.canCast(player, level);
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 10;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             if (player != Game1.player)
                 return;

--- a/Spells/HealSpell.cs
+++ b/Spells/HealSpell.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Magic.Schools;
 using StardewValley;
-using SFarmer = StardewValley.Farmer;
 
 namespace Magic.Spells
 {
@@ -11,17 +10,17 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(SFarmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 5 + 5 * level;
         }
 
-        public override bool canCast(SFarmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             return base.canCast(player, level) && player.health != player.maxHealth;
         }
 
-        public override void onCast(SFarmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             Log.debug(player.Name + " casted Heal.");
             int health = 10 + 15 * level;

--- a/Spells/HealSpell.cs
+++ b/Spells/HealSpell.cs
@@ -20,14 +20,16 @@ namespace Magic.Spells
             return base.canCast(player, level) && player.health != player.maxHealth;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
-            Log.debug(player.Name + " casted Heal.");
+            Log.debug($"{player.Name} cast Heal.");
             int health = 10 + 15 * level;
             player.health += health;
             player.currentLocation.debris.Add(new Debris(health, new Vector2((float)(Game1.player.getStandingX() + 8), (float)Game1.player.getStandingY()), Color.Green, 1f, (Character)Game1.player));
             Game1.playSound("healSound");
             player.addMagicExp(health / 2);
+
+            return null;
         }
     }
 }

--- a/Spells/LanternSpell.cs
+++ b/Spells/LanternSpell.cs
@@ -1,7 +1,6 @@
-﻿using StardewModdingAPI.Events;
-using Magic.Schools;
+﻿using Magic.Schools;
 using StardewValley;
-using System;
+using System.Linq;
 
 namespace Magic.Spells
 {
@@ -11,12 +10,12 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return level;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             if (player != Game1.player)
                 return;

--- a/Spells/LanternSpell.cs
+++ b/Spells/LanternSpell.cs
@@ -1,13 +1,17 @@
-﻿using Magic.Schools;
+﻿using System;
+using Magic.Schools;
 using StardewValley;
-using System.Linq;
 
 namespace Magic.Spells
 {
     class LanternSpell : Spell
     {
-        public LanternSpell() : base( SchoolId.Nature, "lantern" )
+        private readonly Func<long> getNewId;
+
+        public LanternSpell(Func<long> getNewId)
+            : base( SchoolId.Nature, "lantern" )
         {
+            this.getNewId = getNewId;
         }
 
         public override int getManaCost(Farmer player, int level)
@@ -25,10 +29,23 @@ namespace Magic.Spells
                 power = 8;
             else if (level == 2)
                 power = 16;
+
+            // TODO for Stardew Valley 1.3.33: replace the next line with this
+            // player.currentLocation.sharedLights.Add(getUnusedLightSourceID(player.currentLocation), new LightSource(1, Game1.player.position, power));
             player.currentLocation.sharedLights.Add(new LightSource(1, Game1.player.position, power));
             player.addMagicExp(level);
 
             return null;
+        }
+
+        private int getUnusedLightSourceID(GameLocation location)
+        {
+            while (true)
+            {
+                int id = (int)this.getNewId();
+                if (!location.hasLightSource(id))
+                    return id;
+            }
         }
     }
 }

--- a/Spells/LanternSpell.cs
+++ b/Spells/LanternSpell.cs
@@ -30,9 +30,7 @@ namespace Magic.Spells
             else if (level == 2)
                 power = 16;
 
-            // TODO for Stardew Valley 1.3.33: replace the next line with this
-            // player.currentLocation.sharedLights.Add(getUnusedLightSourceID(player.currentLocation), new LightSource(1, Game1.player.position, power));
-            player.currentLocation.sharedLights.Add(new LightSource(1, Game1.player.position, power));
+            player.currentLocation.sharedLights.Add(getUnusedLightSourceID(player.currentLocation), new LightSource(1, Game1.player.position, power));
             player.addMagicExp(level);
 
             return null;

--- a/Spells/LanternSpell.cs
+++ b/Spells/LanternSpell.cs
@@ -15,10 +15,10 @@ namespace Magic.Spells
             return level;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             if (player != Game1.player)
-                return;
+                return null;
 
             int power = 4;
             if (level == 1)
@@ -27,6 +27,8 @@ namespace Magic.Spells
                 power = 16;
             player.currentLocation.sharedLights.Add(new LightSource(1, Game1.player.position, power));
             player.addMagicExp(level);
+
+            return null;
         }
     }
 }

--- a/Spells/LuckStealSpell.cs
+++ b/Spells/LuckStealSpell.cs
@@ -26,15 +26,17 @@ namespace Magic.Spells
             return base.canCast(player, level) && Game1.dailyLuck != 0.12;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
-            Log.debug(player.Name + " casted Luck Steal.");
+            Log.debug($"{player.Name} cast Luck Steal.");
             var num = Game1.random.Next(player.friendshipData.Count());
             var friendshipData = player.friendshipData[new List<string>(player.friendshipData.Keys)[num]];
             friendshipData.Points = Math.Max(0, friendshipData.Points - 250);
             Game1.dailyLuck = 0.12;
             Game1.playSound("death");
             player.addMagicExp(50);
+
+            return null;
         }
     }
 }

--- a/Spells/LuckStealSpell.cs
+++ b/Spells/LuckStealSpell.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Magic.Schools;
+﻿using Magic.Schools;
 using StardewValley;
-using SFarmer = StardewValley.Farmer;
 using System.Collections.Generic;
 using System;
 
@@ -13,7 +11,7 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(SFarmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
@@ -23,12 +21,12 @@ namespace Magic.Spells
             return 1;
         }
 
-        public override bool canCast(SFarmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             return base.canCast(player, level) && Game1.dailyLuck != 0.12;
         }
 
-        public override void onCast(SFarmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             Log.debug(player.Name + " casted Luck Steal.");
             var num = Game1.random.Next(player.friendshipData.Count());

--- a/Spells/MeteorSpell.cs
+++ b/Spells/MeteorSpell.cs
@@ -11,7 +11,8 @@ namespace Magic.Spells
 {
     class MeteorSpell : Spell
     {
-        public MeteorSpell() : base( SchoolId.Eldritch, "meteor" )
+        public MeteorSpell() 
+            : base( SchoolId.Eldritch, "meteor" )
         {
         }
 
@@ -30,47 +31,50 @@ namespace Magic.Spells
             return 1;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
-            new Meteor(player, targetX, targetY);
             player.consumeObject(SObject.iridium, 1);
+            return new Meteor(player, targetX, targetY);
         }
     }
     
-    internal class Meteor
+    internal class Meteor : IActiveEffect
     {
         private readonly GameLocation loc;
         private readonly Farmer source;
-
-        private Vector2 position = new Vector2();
-        private float yVelocity;
+        private static readonly Random rand = new Random();
+        private readonly Vector2 position;
+        private readonly float yVelocity;
         private float height = 1000;
 
         public Meteor(Farmer theSource, int tx, int ty)
         {
             loc = theSource.currentLocation;
             source = theSource;
-                
+
             position.X = tx;
             position.Y = ty;
             yVelocity = 64;
-
-            GameEvents.UpdateTick += update;
-            GraphicsEvents.OnPreRenderHudEvent += render;
         }
 
-        private static Random rand = new Random();
-        public void update(object sender, EventArgs args)
+        /// <summary>Update the effect state if needed.</summary>
+        /// <param name="e">The update tick event args.</param>
+        /// <returns>Returns true if the effect is still active, or false if it can be discarded.</returns>
+        public bool Update(UpdateTickedEventArgs e)
         {
+            // decrease height until zero
             height -= (int)yVelocity;
-            if (height <= 0)
+            if (height > 0)
+                return true;
+
+            // trigger explosion
             {
                 Game1.playSound("explosion");
                 for (int i = 0; i < 10; ++i)
                 {
                     for (int ix = -i; ix <= i; ++ix)
-                        for (int iy = -i; iy <= i; ++iy)
-                            Game1.createRadialDebris(loc, Game1.objectSpriteSheetName, new Rectangle(352, 400, 32, 32), 4, (int)this.position.X + ix * 20, (int)this.position.Y + iy * 20, 15 - 14 + rand.Next(15 - 14), (int)((double)this.position.Y / (double)Game1.tileSize) + 1, new Color(255, 255, 255, 255), 4.0f);
+                    for (int iy = -i; iy <= i; ++iy)
+                        Game1.createRadialDebris(loc, Game1.objectSpriteSheetName, new Rectangle(352, 400, 32, 32), 4, (int)this.position.X + ix * 20, (int)this.position.Y + iy * 20, 15 - 14 + rand.Next(15 - 14), (int)((double)this.position.Y / (double)Game1.tileSize) + 1, new Color(255, 255, 255, 255), 4.0f);
                 }
                 foreach (var npc in source.currentLocation.characters)
                 {
@@ -85,17 +89,16 @@ namespace Magic.Spells
                     }
                 }
                 loc.explode(new Vector2((int)position.X / Game1.tileSize, (int)position.Y / Game1.tileSize), 4 + 2, source);
-
-                GameEvents.UpdateTick -= update;
-                GraphicsEvents.OnPreRenderHudEvent -= render;
+                return false;
             }
         }
 
-        public void render(object sender, EventArgs args)
+        /// <summary>Draw the effect to the screen if needed.</summary>
+        /// <param name="spriteBatch">The sprite batch being drawn.</param>
+        public void Draw(SpriteBatch spriteBatch)
         {
-            SpriteBatch b = Game1.spriteBatch;
             Vector2 drawPos = Game1.GlobalToLocal(new Vector2(position.X, position.Y - height));
-            b.Draw(Game1.objectSpriteSheet, drawPos, new Rectangle(352, 400, 32, 32), Color.White, 0, new Vector2(16, 16), 2 + 8, SpriteEffects.None, (float)(((double)this.position.Y - height + (double)(Game1.tileSize * 3 / 2)) / 10000.0));
+            spriteBatch.Draw(Game1.objectSpriteSheet, drawPos, new Rectangle(352, 400, 32, 32), Color.White, 0, new Vector2(16, 16), 2 + 8, SpriteEffects.None, (float)(((double)this.position.Y - height + (double)(Game1.tileSize * 3 / 2)) / 10000.0));
         }
     }
 }

--- a/Spells/MeteorSpell.cs
+++ b/Spells/MeteorSpell.cs
@@ -5,7 +5,6 @@ using Magic.Schools;
 using StardewValley;
 using StardewValley.Monsters;
 using System;
-using SFarmer = StardewValley.Farmer;
 using SObject = StardewValley.Object;
 
 namespace Magic.Spells
@@ -16,12 +15,12 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override bool canCast(StardewValley.Farmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             return base.canCast(player, level) && player.hasItemInInventory(SObject.iridium, 1);
         }
@@ -31,7 +30,7 @@ namespace Magic.Spells
             return 1;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             new Meteor(player, targetX, targetY);
             player.consumeObject(SObject.iridium, 1);
@@ -41,13 +40,13 @@ namespace Magic.Spells
     internal class Meteor
     {
         private readonly GameLocation loc;
-        private readonly SFarmer source;
+        private readonly Farmer source;
 
         private Vector2 position = new Vector2();
         private float yVelocity;
         private float height = 1000;
 
-        public Meteor(SFarmer theSource, int tx, int ty)
+        public Meteor(Farmer theSource, int tx, int ty)
         {
             loc = theSource.currentLocation;
             source = theSource;

--- a/Spells/PhotosynthesisSpell.cs
+++ b/Spells/PhotosynthesisSpell.cs
@@ -18,17 +18,17 @@ namespace Magic.Spells
             return 1;
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override bool canCast(StardewValley.Farmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             return base.canCast(player, level) && player.hasItemInInventory(SObject.prismaticShardIndex, 1);
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             List<GameLocation> locs = new List<GameLocation>();
             locs.Add(Game1.getLocationFromName("Farm"));

--- a/Spells/PhotosynthesisSpell.cs
+++ b/Spells/PhotosynthesisSpell.cs
@@ -28,7 +28,7 @@ namespace Magic.Spells
             return base.canCast(player, level) && player.hasItemInInventory(SObject.prismaticShardIndex, 1);
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             List<GameLocation> locs = new List<GameLocation>();
             locs.Add(Game1.getLocationFromName("Farm"));
@@ -75,6 +75,7 @@ namespace Magic.Spells
             }
 
             player.consumeObject( SObject.prismaticShardIndex, 1 );
+            return null;
         }
     }
 }

--- a/Spells/ProjectileSpell.cs
+++ b/Spells/ProjectileSpell.cs
@@ -1,7 +1,6 @@
 ﻿using Magic.Game;
 using StardewValley;
 using System;
-using SFarmer = StardewValley.Farmer;
 
 namespace Magic.Spells
 {
@@ -28,12 +27,12 @@ namespace Magic.Spells
             SoundHit = sndHit;
         }
 
-        public override int getManaCost(SFarmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return ManaBase + ManaIncr * level;
         }
 
-        public override void onCast(SFarmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             Log.debug(player.Name + " casted " + Id + ".");
 

--- a/Spells/ProjectileSpell.cs
+++ b/Spells/ProjectileSpell.cs
@@ -32,15 +32,17 @@ namespace Magic.Spells
             return ManaBase + ManaIncr * level;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
-            Log.debug(player.Name + " casted " + Id + ".");
+            Log.debug($"{player.Name} cast {Id}.");
 
             int dmg = DamageBase + DamageIncr * level;
             float dir = ( float ) -Math.Atan2(player.getStandingY() - targetY, targetX - player.getStandingX());
             player.currentLocation.projectiles.Add(new SpellProjectile(player, this, dmg, dir, 3f + 2 * level));
             if ( Sound != null )
                 Game1.playSound(Sound);
+
+            return null;
         }
     }
 }

--- a/Spells/ShockwaveSpell.cs
+++ b/Spells/ShockwaveSpell.cs
@@ -4,6 +4,7 @@ using Magic.Schools;
 using StardewValley;
 using StardewValley.Monsters;
 using System;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace Magic.Spells
 {
@@ -23,23 +24,21 @@ namespace Magic.Spells
             return 0;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             player.jump();
-            new Shockwave(player, level);
+            return new Shockwave(player, level);
         }
 
-        private class Shockwave
+        private class Shockwave : IActiveEffect
         {
-            private Farmer player;
-            private int level;
+            private readonly Farmer player;
+            private readonly int level;
 
             public Shockwave( Farmer player, int level )
             {
                 this.player = player;
                 this.level = level;
-
-                GameEvents.UpdateTick += update;
             }
 
             private bool jumping = true;
@@ -47,7 +46,11 @@ namespace Magic.Spells
             private float landX, landY;
             private float timer = 0;
             private int currRad = 0;
-            private void update( object sender, EventArgs args )
+
+            /// <summary>Update the effect state if needed.</summary>
+            /// <param name="e">The update tick event args.</param>
+            /// <returns>Returns true if the effect is still active, or false if it can be discarded.</returns>
+            public bool Update(UpdateTickedEventArgs e)
             {
                 if (jumping)
                 {
@@ -61,14 +64,14 @@ namespace Magic.Spells
                 }
                 if (!jumping)
                 {
-                    if ( --timer > 0 )
+                    if (--timer > 0)
                     {
-                        return;
+                        return true;
                     }
                     timer = 10;
 
                     int spotsForCurrRadius = 1 + currRad * 7;
-                    for ( int i = 0; i < spotsForCurrRadius; ++i )
+                    for (int i = 0; i < spotsForCurrRadius; ++i)
                     {
                         Game1.playSound("hoeHit");
                         float ix = landX + (float)Math.Cos(Math.PI * 2 / spotsForCurrRadius * i) * currRad * Game1.tileSize;
@@ -90,10 +93,16 @@ namespace Magic.Spells
                         }
                     }
 
-                    if ( currRad >= 1 + ( level + 1 ) * 2 )
-                        GameEvents.UpdateTick -= update;
+                    if (currRad >= 1 + (level + 1) * 2)
+                        return false;
                 }
+
+                return true;
             }
+
+            /// <summary>Draw the effect to the screen if needed.</summary>
+            /// <param name="spriteBatch">The sprite batch being drawn.</param>
+            public void Draw(SpriteBatch spriteBatch) { }
         }
     }
 }

--- a/Spells/ShockwaveSpell.cs
+++ b/Spells/ShockwaveSpell.cs
@@ -13,17 +13,17 @@ namespace Magic.Spells
         {
         }
 
-        public override bool canCast(StardewValley.Farmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             return base.canCast(player, level) && player.yJumpVelocity == 0;
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             player.jump();
             new Shockwave(player, level);
@@ -31,10 +31,10 @@ namespace Magic.Spells
 
         private class Shockwave
         {
-            private StardewValley.Farmer player;
+            private Farmer player;
             private int level;
 
-            public Shockwave( StardewValley.Farmer player, int level )
+            public Shockwave( Farmer player, int level )
             {
                 this.player = player;
                 this.level = level;

--- a/Spells/Spell.cs
+++ b/Spells/Spell.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Magic.Schools;
-using SFarmer = StardewValley.Farmer;
+using StardewValley;
 
 namespace Magic.Spells
 {
@@ -28,16 +28,16 @@ namespace Magic.Spells
             return 3;
         }
 
-        public abstract int getManaCost(SFarmer player, int level);
+        public abstract int getManaCost(Farmer player, int level);
 
-        public virtual bool canCast(SFarmer player, int level)
+        public virtual bool canCast(Farmer player, int level)
         {
             return player.knowsSpell(FullId, level) && player.getCurrentMana() >= getManaCost( player, level );
         }
 
         // Support non-instant casting?
 
-        public abstract void onCast(SFarmer player, int level, int targetX, int targetY);
+        public abstract void onCast(Farmer player, int level, int targetX, int targetY);
 
         public virtual void loadIcon()
         {

--- a/Spells/Spell.cs
+++ b/Spells/Spell.cs
@@ -35,9 +35,7 @@ namespace Magic.Spells
             return player.knowsSpell(FullId, level) && player.getCurrentMana() >= getManaCost( player, level );
         }
 
-        // Support non-instant casting?
-
-        public abstract void onCast(Farmer player, int level, int targetX, int targetY);
+        public abstract IActiveEffect onCast(Farmer player, int level, int targetX, int targetY);
 
         public virtual void loadIcon()
         {

--- a/Spells/TeleportSpell.cs
+++ b/Spells/TeleportSpell.cs
@@ -27,9 +27,10 @@ namespace Magic
             return 0;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             Game1.activeClickableMenu = new TeleportMenu();
+            return null;
         }
     }
 }

--- a/Spells/TeleportSpell.cs
+++ b/Spells/TeleportSpell.cs
@@ -17,17 +17,17 @@ namespace Magic
             return 1;
         }
 
-        public override bool canCast(StardewValley.Farmer player, int level)
+        public override bool canCast(Farmer player, int level)
         {
             return base.canCast(player, level) && player.currentLocation.IsOutdoors && player.mount == null && player.hasItemInInventory(Mod.ja.GetObjectId("Travel Core"), 1);
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             Game1.activeClickableMenu = new TeleportMenu();
         }

--- a/Spells/TendrilsSpell.cs
+++ b/Spells/TendrilsSpell.cs
@@ -15,12 +15,12 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             foreach ( var npc in player.currentLocation.characters )
             {

--- a/Spells/TendrilsSpell.cs
+++ b/Spells/TendrilsSpell.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using StardewModdingAPI.Events;
 using Magic.Schools;
 using StardewValley;
 using StardewValley.Monsters;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using StardewModdingAPI.Events;
 
 namespace Magic.Spells
 {
@@ -20,8 +22,9 @@ namespace Magic.Spells
             return 0;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
+            TendrilGroup tendrils = new TendrilGroup();
             foreach ( var npc in player.currentLocation.characters )
             {
                 if ( npc is Monster mob )
@@ -30,20 +33,50 @@ namespace Magic.Spells
                     int dur = ( level * 2 + 5 ) * 60;
                     if ( Vector2.Distance(mob.position, new Vector2( targetX, targetY ) ) <= rad )
                     {
-                        new Tendril(mob, new Vector2(targetX, targetY), rad, dur );
+                        tendrils.Add(new Tendril(mob, new Vector2(targetX, targetY), rad, dur ));
                         player.addMagicExp(3);
                     }
                 }
             }
+
+            return tendrils.Any()
+                ? tendrils
+                : null;
         }
 
-        private class Tendril
+        private class TendrilGroup : List<Tendril>, IActiveEffect
         {
-            private Monster mob;
-            private Vector2 pos;
-            private float radius;
+            /// <summary>Update the effect state if needed.</summary>
+            /// <param name="e">The update tick event args.</param>
+            /// <returns>Returns true if the effect is still active, or false if it can be discarded.</returns>
+            public bool Update(UpdateTickedEventArgs e)
+            {
+                for (int i = this.Count - 1; i >= 0; i--)
+                {
+                    Tendril tendril = this[i];
+                    if (!tendril.Update(e))
+                        this.RemoveAt(i);
+                }
+
+                return this.Any();
+            }
+
+            /// <summary>Draw the effect to the screen if needed.</summary>
+            /// <param name="spriteBatch">The sprite batch being drawn.</param>
+            public void Draw(SpriteBatch spriteBatch)
+            {
+                foreach (Tendril tendril in this)
+                    tendril.Draw(spriteBatch);
+            }
+        }
+
+        private class Tendril : IActiveEffect
+        {
+            private readonly Monster mob;
+            private readonly Vector2 pos;
+            private readonly float radius;
+            private readonly Texture2D tex;
             private int duration;
-            private Texture2D tex;
 
             public Tendril( Monster theMob, Vector2 pos, float rad, int dur )
             {
@@ -52,15 +85,15 @@ namespace Magic.Spells
                 radius = rad;
                 duration = dur;
                 tex = Content.loadTexture("magic/nature/tendrils/tendril.png");
-
-                GameEvents.UpdateTick += update;
-                GraphicsEvents.OnPreRenderHudEvent += render;
             }
 
-            private void update( object sender, EventArgs args )
+            /// <summary>Update the effect state if needed.</summary>
+            /// <param name="e">The update tick event args.</param>
+            /// <returns>Returns true if the effect is still active, or false if it can be discarded.</returns>
+            public bool Update(UpdateTickedEventArgs e)
             {
                 Vector2 mobPos = new Vector2(mob.GetBoundingBox().Center.X, mob.GetBoundingBox().Center.Y);
-                if ( Vector2.Distance( mobPos, pos ) >= radius )
+                if (Vector2.Distance(mobPos, pos) >= radius)
                 {
                     Vector2 offset = mob.position - pos;
                     offset.Normalize();
@@ -68,21 +101,19 @@ namespace Magic.Spells
                     mob.position.Value = pos + offset;
                 }
 
-                if ( --duration <= 0 )
-                {
-                    GameEvents.UpdateTick -= update;
-                    GraphicsEvents.OnPreRenderHudEvent -= render;
-                }
+                return --duration > 0;
             }
 
-            private void render( object sender, EventArgs args )
+            /// <summary>Draw the effect to the screen if needed.</summary>
+            /// <param name="spriteBatch">The sprite batch being drawn.</param>
+            public void Draw(SpriteBatch spriteBatch)
             {
                 Vector2 mobPos = new Vector2(mob.GetBoundingBox().Center.X, mob.GetBoundingBox().Center.Y);
                 var dist = Vector2.Distance(mobPos, pos);
                 Rectangle r = new Rectangle((int)pos.X, (int)pos.Y, 10, (int)dist);
                 r = Game1.GlobalToLocal(Game1.viewport, r);
-                float rot = (float) -Math.Atan2(pos.Y - mobPos.Y, mobPos.X - pos.X);
-                Game1.spriteBatch.Draw(tex, r, new Rectangle(0,0,10,12), Color.White, rot - 3.14f / 2, new Vector2(5, 0), SpriteEffects.None, 1);
+                float rot = (float)-Math.Atan2(pos.Y - mobPos.Y, mobPos.X - pos.X);
+                spriteBatch.Draw(tex, r, new Rectangle(0, 0, 10, 12), Color.White, rot - 3.14f / 2, new Vector2(5, 0), SpriteEffects.None, 1);
             }
         }
     }

--- a/Spells/TillSpell.cs
+++ b/Spells/TillSpell.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using SpaceCore.Utilities;
 using Magic.Schools;
 using StardewValley;
 using StardewValley.Tools;
@@ -12,12 +11,12 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             level += 1;
             targetX /= Game1.tileSize;

--- a/Spells/TillSpell.cs
+++ b/Spells/TillSpell.cs
@@ -16,7 +16,7 @@ namespace Magic.Spells
             return 0;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             level += 1;
             targetX /= Game1.tileSize;
@@ -32,7 +32,7 @@ namespace Magic.Spells
                 for (int iy = targetY - level; iy <= targetY + level; ++iy)
                 {
                     if (player.getCurrentMana() <= 0)
-                        return;
+                        return null;
 
                     Vector2 pos = new Vector2(ix, iy);
                     if (loc.terrainFeatures.ContainsKey(pos))
@@ -81,6 +81,8 @@ namespace Magic.Spells
                     }
                 }
             }
+
+            return null;
         }
     }
 }

--- a/Spells/WaterSpell.cs
+++ b/Spells/WaterSpell.cs
@@ -11,12 +11,12 @@ namespace Magic.Spells
         {
         }
 
-        public override int getManaCost(StardewValley.Farmer player, int level)
+        public override int getManaCost(Farmer player, int level)
         {
             return 0;
         }
 
-        public override void onCast(StardewValley.Farmer player, int level, int targetX, int targetY)
+        public override void onCast(Farmer player, int level, int targetX, int targetY)
         {
             level += 1;
             targetX /= Game1.tileSize;

--- a/Spells/WaterSpell.cs
+++ b/Spells/WaterSpell.cs
@@ -16,7 +16,7 @@ namespace Magic.Spells
             return 0;
         }
 
-        public override void onCast(Farmer player, int level, int targetX, int targetY)
+        public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             level += 1;
             targetX /= Game1.tileSize;
@@ -31,7 +31,7 @@ namespace Magic.Spells
                 for (int iy = targetY - level; iy <= targetY + level; ++iy)
                 {
                     if (player.getCurrentMana() <= 0)
-                        return;
+                        return null;
 
                     Vector2 pos = new Vector2(ix, iy);
                     if (!loc.terrainFeatures.ContainsKey(pos))
@@ -54,6 +54,8 @@ namespace Magic.Spells
                     Game1.playSound("wateringCan");
                 }
             }
+
+            return null;
         }
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,17 +4,12 @@
   "Version": "0.1.4",
   "Description": "Magic!",
   "UniqueID": "spacechase0.Magic",
-  "PerSaveConfigs": false,
   "EntryDll": "Magic.dll",
-  "MinimumApiVersion": "1.14-prerelease",
+  "MinimumApiVersion": "2.9.0",
   "UpdateKeys": [ "Nexus:2007", "Chucklefish:5242" ],
   "Dependencies": [
-    {
-      "UniqueID": "spacechase0.SpaceCore"
-    },
-    {
-      "UniqueID": "spacechase0.JsonAssets"
-    }
+    { "UniqueID": "spacechase0.SpaceCore" },
+    { "UniqueID": "spacechase0.JsonAssets" }
   ],
   "spacechase0": "magic"
 }

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180428" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
This pull request...

* Adds 'active effects' to support non-instantaneous spells.  
  _A spell can return an `IActiveEffect` from its `onCast` method, and the mod will run the effect's `Update` and `Draw` methods until the effect ends. That's currently used for the meteor, shockwave, and tendril spells._
* Updates the code for Stardew Valley 1.3.33 and the upcoming SMAPI 3.0 (still compatible with current versions of SMAPI).
* Updates NuGet packages.
* Migrates to the new package reference format.
* Performs minor cleanup.

Let me know if you want me to change anything!