### PR TITLE
Two bug fixes

### DIFF
--- a/Spells/ClearDebrisSpell.cs
+++ b/Spells/ClearDebrisSpell.cs
@@ -125,10 +125,10 @@ namespace Magic.Spells
                                 }
                             }
                         }
-                        catch(System.NullReferenceException e)
-                        {
-                            // Something in GetField above gets upset if this tries to get called outside of the farm for some reason
-                        }
+                        // Something in GetField above gets upset if this tries to get called outside of the farm for some reason
+                        catch (System.NullReferenceException e)
+                        { }
+                        catch (System.InvalidCastException e) { }
                     }
                 }
             }

--- a/Spells/ClearDebrisSpell.cs
+++ b/Spells/ClearDebrisSpell.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Magic.Schools;
+using SpaceShared;
 using StardewValley;
 using StardewValley.Locations;
 using StardewValley.TerrainFeatures;
@@ -101,24 +102,32 @@ namespace Magic.Spells
 
                     if (level >= 3)
                     {
-                        ICollection< ResourceClump > clumps = (NetCollection<ResourceClump>) loc.GetType().GetField("resourceClumps", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance).GetValue(loc);
-                        if (loc is Woods)
-                            clumps = (loc as Woods).stumps;
-                        if ( clumps != null )
+                        try
                         {
-                            foreach ( var rc in clumps )
+                            ICollection<ResourceClump> clumps = (NetCollection<ResourceClump>)loc.GetType().GetField("resourceClumps", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance).GetValue(loc);
+
+                            if (loc is Woods)
+                                clumps = (loc as Woods).stumps;
+                            if (clumps != null)
                             {
-                                if (new Rectangle((int)rc.tile.X, (int)rc.tile.Y, rc.width.Value, rc.height.Value).Contains(ix, iy))
+                                foreach (var rc in clumps)
                                 {
-                                    player.addMana(-3);
-                                    if (rc.performToolAction(dummyAxe, 1, pos, loc) || rc.performToolAction(dummyPick, 1, pos, loc))
+                                    if (new Rectangle((int)rc.tile.X, (int)rc.tile.Y, rc.width.Value, rc.height.Value).Contains(ix, iy))
                                     {
-                                        clumps.Remove(rc);
-                                        player.AddCustomSkillExperience(Magic.Skill,10);
+                                        player.addMana(-3);
+                                        if (rc.performToolAction(dummyAxe, 1, pos, loc) || rc.performToolAction(dummyPick, 1, pos, loc))
+                                        {
+                                            clumps.Remove(rc);
+                                            player.AddCustomSkillExperience(Magic.Skill, 10);
+                                        }
+                                        break;
                                     }
-                                    break;
                                 }
                             }
+                        }
+                        catch(System.NullReferenceException e)
+                        {
+                            // Something in GetField above gets upset if this tries to get called outside of the farm for some reason
                         }
                     }
                 }

--- a/Spells/HealSpell.cs
+++ b/Spells/HealSpell.cs
@@ -24,9 +24,9 @@ namespace Magic.Spells
         public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             int health = 10 + 15 * level + (player.CombatLevel + 1) * 2;
-            if (player.health + health >= player.maxHealth)
-                health = player.maxHealth;
             player.health += health;
+            if (player.health >= player.maxHealth)
+                player.health = player.maxHealth;
             player.currentLocation.debris.Add(new Debris(health, new Vector2((float)(Game1.player.getStandingX() + 8), (float)Game1.player.getStandingY()), Color.Green, 1f, (Character)Game1.player));
             Game1.playSound("healSound");
             player.AddCustomSkillExperience(Magic.Skill, health / 2);

--- a/Spells/HealSpell.cs
+++ b/Spells/HealSpell.cs
@@ -25,7 +25,7 @@ namespace Magic.Spells
         {
             int health = 10 + 15 * level + (player.CombatLevel + 1) * 2;
             if (player.health + health >= player.maxHealth)
-                health = player.maxHealth - player.health;
+                health = player.maxHealth;
             player.health += health;
             player.currentLocation.debris.Add(new Debris(health, new Vector2((float)(Game1.player.getStandingX() + 8), (float)Game1.player.getStandingY()), Color.Green, 1f, (Character)Game1.player));
             Game1.playSound("healSound");

--- a/Spells/HealSpell.cs
+++ b/Spells/HealSpell.cs
@@ -24,6 +24,8 @@ namespace Magic.Spells
         public override IActiveEffect onCast(Farmer player, int level, int targetX, int targetY)
         {
             int health = 10 + 15 * level + (player.CombatLevel + 1) * 2;
+            if (player.health + health >= player.maxHealth)
+                health = player.maxHealth - player.health;
             player.health += health;
             player.currentLocation.debris.Add(new Debris(health, new Vector2((float)(Game1.player.getStandingX() + 8), (float)Game1.player.getStandingY()), Color.Green, 1f, (Character)Game1.player));
             Game1.playSound("healSound");


### PR DESCRIPTION
The healing spell allows you to overheal as much as you want, I've included a fix to cap healing to max player health.
Other bug is clear debris level 3 not working outside of the farm, which has to do with the code getting clumps. I tried to find which part it was exactly, but I couldn't isolate it and gave up and just put in a try/catch block.